### PR TITLE
Add stop layer on map

### DIFF
--- a/app/configurations/config.mhdev.js
+++ b/app/configurations/config.mhdev.js
@@ -33,7 +33,7 @@ export default configMerger(walttiConfig, {
       default: `${MAP_URL}/styles/v1/kyyticom/cjvytj9650p4a1clh3qbzxspe/tiles/`,
       sv: `${MAP_URL}/styles/v1/kyyticom/cjvytj9650p4a1clh3qbzxspe/tiles/`,
     },
-    STOP_MAP: null,
+    STOP_MAP: `${API_URL}/otp/routers/default/vectorTiles/stops,stations/`,
     CITYBIKE_MAP: null,
     OTP: `${API_URL}/otp/routers/default/`,
   },

--- a/app/configurations/config.mhdev.js
+++ b/app/configurations/config.mhdev.js
@@ -30,8 +30,8 @@ export default configMerger(walttiConfig, {
     GEOCODING_BASE_URL: 'https://devapi.tuup.fi',
     MAP_URL,
     MAP: {
-      default: `${MAP_URL}/styles/v1/kyyticom/cjvytj9650p4a1clh3qbzxspe/tiles/`,
-      sv: `${MAP_URL}/styles/v1/kyyticom/cjvytj9650p4a1clh3qbzxspe/tiles/`,
+      default: `${MAP_URL}/styles/v1/kyyticom/ckfoy6sug0kci19ql1i7vokr7/tiles/`,
+      sv: `${MAP_URL}/styles/v1/kyyticom/ckfoy6sug0kci19ql1i7vokr7/tiles/`,
     },
     STOP_MAP: `${API_URL}/otp/routers/default/vectorTiles/stops,stations/`,
     CITYBIKE_MAP: null,


### PR DESCRIPTION
We should probably remove icons from base map?

## Proposed Changes

  - Update STOP_MAP_URL to fetch vector tiles from OTP

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
