### PR TITLE
Enable banning MDR routes in Porvoo

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -549,6 +549,7 @@ const containerComponent = Relay.createContainer(SummaryPageWithBreakpoint, {
           modeWeight: $modeWeight
           preferred: $preferred,
           unpreferred: $unpreferred,
+          banned: $banned,
           allowedBikeRentalNetworks: $allowedBikeRentalNetworks,
           locale: $locale,
         ),
@@ -600,6 +601,7 @@ const containerComponent = Relay.createContainer(SummaryPageWithBreakpoint, {
       maxWalkDistance: 0,
       preferred: null,
       unpreferred: null,
+      banned: null,
       ticketTypes: null,
       itineraryFiltering: ITINERARYFILTERING_DEFAULT,
       minTransferTime: null,

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -334,6 +334,7 @@ class SummaryPlanContainer extends React.Component {
       $disableRemainingWeightHeuristic:Boolean!,
       $preferred:InputPreferred!,
       $unpreferred: InputUnpreferred!,
+      $banned: InputBanned!
       $fromPlace:String!,
       $toPlace:String!
       $date: String!,
@@ -378,6 +379,7 @@ class SummaryPlanContainer extends React.Component {
           arriveBy:$arriveBy,
           preferred:$preferred,
           unpreferred: $unpreferred,
+          banned:$banned,
           transportModes:$modes
           transferPenalty:$transferPenalty,
           ignoreRealtimeUpdates:$ignoreRealtimeUpdates,

--- a/app/configurations/config.mh.js
+++ b/app/configurations/config.mh.js
@@ -88,6 +88,11 @@ export default configMerger(walttiConfig, {
     [20.212469, 69.475061]
   ],
 
+  defaultSettings: {
+    banned: {
+      agencies: "MDR-Porvoo:Porvoo"
+    }
+  },
 
   footer: {
     content: [

--- a/app/configurations/config.mhdev.js
+++ b/app/configurations/config.mhdev.js
@@ -88,6 +88,11 @@ export default configMerger(walttiConfig, {
     [20.212469, 69.475061]
   ],
 
+  defaultSettings: {
+    banned: {
+      agencies: "MDR-Porvoo:Porvoo"
+    }
+  },
 
   footer: {
     content: [


### PR DESCRIPTION
## Proposed Changes

  - Pass banned argument to plan query
  - Add "MDR-Porvoo:Porvoo" as a banned agency in Matkahuolto configs

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
